### PR TITLE
uninitialized constant HashWithIndifferentAccess (NameError)

### DIFF
--- a/lib/rconfig.rb
+++ b/lib/rconfig.rb
@@ -59,6 +59,7 @@
 #  ...
 #
 require 'active_support'
+require 'active_support/hash_with_indifferent_access'
 require 'rconfig/core_ext/array'
 require 'rconfig/core_ext/hash'
 require 'rconfig/core_ext/nil'


### PR DESCRIPTION
This fixe solve #2.

I've fixed this by adding explicit HashWithIndifferentAccess require in lib/rconfig.rb.
