### PR TITLE
config_paths should be load_paths

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,7 +65,7 @@ Starting with version 0.4.0, RConfig requires at least Ruby 1.9, and Rails 3. Pr
 
  demo.rb => 
   require 'rconfig'
-  RConfig.config_paths = ['$HOME/config', '#{APP_ROOT}/config', '/demo/conf']
+  RConfig.load_paths = ['$HOME/config', '#{APP_ROOT}/config', '/demo/conf']
   RConfig.demo[:server][:port] => 81
   RConfig.demo.server.address  => 'host.domain.com'
   RConfig.demo.server.host     => 'host.local'


### PR DESCRIPTION
in the README files it says to load configuration with the config_paths= method.

However that didn't work for me. I tried with load_paths=. That worked fine. So I think the Documentation is not 100% correct (or there is another bug)

I only tried with a non-Rails project
