### PR TITLE
Fixing rspec test, new Active Support convert_value method signature and version bump

### DIFF
--- a/lib/rconfig.rb
+++ b/lib/rconfig.rb
@@ -65,7 +65,7 @@ require 'rconfig/core_ext/hash'
 require 'rconfig/core_ext/nil'
 
 module RConfig
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 
   autoload :Socket,                    'socket'
   autoload :YAML,                      'yaml'

--- a/lib/rconfig/config.rb
+++ b/lib/rconfig/config.rb
@@ -79,7 +79,7 @@ module RConfig
     ##
     # Override HashWithIndifferentAccess#convert_value
     # return instance of Config for Hash values.
-    def convert_value(value)
+    def convert_value(value, options = {})
       value.is_a?(Hash) ? self.class.new(value).freeze : super
     end
 

--- a/spec/rconfig_spec.rb
+++ b/spec/rconfig_spec.rb
@@ -58,7 +58,7 @@ describe RConfig do
 
     it 'should parse xml files with activesupport hash' do
       contents = "<admin><name>/Users/rahmal</name><home>rahmal</home></admin>"
-      Hash.should_receive(:from_xml).with(contents)
+      Hash.should_receive(:from_xml).with(contents).and_call_original
       RConfig.parse(contents, 'xml_file', :xml)
     end
   end


### PR DESCRIPTION
The signature of the method HashWithIndifferentAccess#convert_value has changed in ActiveSupport 4.0.2: http://apidock.com/rails/v4.0.2/ActiveSupport/HashWithIndifferentAccess/convert_value

I also need to use and_call_original to make the test pass on spec/rconfig_spec.rb
